### PR TITLE
Manual Gradient Accumulation in Pjit

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,6 +1,6 @@
 training:
   max_epochs: 8
-  batch_size: 8
+  batch_size: 64
   peak_learning_rate: 2.5e-4
   warmup_steps: 2000
   decay_steps: 176400
@@ -8,7 +8,7 @@ training:
   end_learning_rate: 2.5e-5
   weight_decay: 0.1
   # corresponds to full CTX BS of 256 on 4 host TPU -> reshape to 512 CTX BS of 512
-  gradient_accumulation_steps: 8 
+  gradient_accumulation_steps: 1 
   evaluation_frequency: 500
   maximum_evaluation_steps: 500
   precision: 'bf16'

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -8,7 +8,7 @@ training:
   end_learning_rate: 2.5e-5
   weight_decay: 0.1
   # corresponds to full CTX BS of 256 on 4 host TPU -> reshape to 512 CTX BS of 512
-  gradient_accumulation_steps: 1 
+  gradient_accumulation_steps: 8
   evaluation_frequency: 500
   maximum_evaluation_steps: 500
   precision: 'bf16'

--- a/conf/model_config.yaml
+++ b/conf/model_config.yaml
@@ -22,7 +22,7 @@ small:
   embedding_dim: 256
   vocab_size: 50258
   num_head: 8
-  block_size: 64
+  block_size: 128
   dropout: 0.5
   N: 4
   fused_residuals: True

--- a/main.py
+++ b/main.py
@@ -364,7 +364,7 @@ def main():
 
     vl = DataLoader(
         dataset=validation_dataset,
-        batch_size=cfg.training.batch_size,
+        batch_size=cfg.training.batch_size//8,
         collate_fn=numpy_collate,
         drop_last=True,
     )

--- a/main.py
+++ b/main.py
@@ -385,7 +385,7 @@ def main():
         with mesh:
             pjit_train_step = pjit(
                 partial(train_step, param_spec=param_spec),
-                in_axis_resources=(state_spec, PartitionSpec("dp"), None),
+                in_axis_resources=(state_spec, PartitionSpec(None, "dp"), None),
                 out_axis_resources=(state_spec, None),
                 donate_argnums=(0,),
             )

--- a/main.py
+++ b/main.py
@@ -424,7 +424,8 @@ def main():
             text = text.reshape(-1, seq_len)
 
             # we add a 'grad_accum' batch dimension
-            text = text.reshape(text.shape[0]//8, 8, seq_len)
+            # in our case, we have BS (64, 512) -> (grad_accum_cnt, bs, 512)
+            text = text.reshape(8, text.shape[0]//8, seq_len)
         
             t0 = time.time()
 

--- a/main.py
+++ b/main.py
@@ -52,15 +52,13 @@ def parse():
 
 
 def save_checkpoint(state, workdir, bucket_path=None, client=None):
-    # if jax.process_index() == 0:
-    #     step = int(state.step)
-    #     checkpoints.save_checkpoint(workdir, state, step, keep=3, overwrite=True)
-    return None
+    if jax.process_index() == 0:
+        step = int(state.step)
+        checkpoints.save_checkpoint(workdir, state, step, keep=3, overwrite=True)
 
 
 def restore_checkpoint(state, workdir, prefix):
-    # return checkpoints.restore_checkpoint(workdir, state, prefix=prefix)
-    return None
+    return checkpoints.restore_checkpoint(workdir, state, prefix=prefix)
 
 
 def main():
@@ -133,7 +131,6 @@ def main():
             learning_rate_fn,
             weight_decay=cfg.training.weight_decay,
             model=model,
-            grad_accum_steps=cfg.training.gradient_accumulation_steps,
         )
         param_spec = None
 
@@ -167,7 +164,6 @@ def main():
             learning_rate_fn,
             weight_decay=cfg.training.weight_decay,
             model=model,
-            grad_accum_steps=cfg.training.gradient_accumulation_steps,
             param_shape=param_shape,
         )
 
@@ -210,7 +206,6 @@ def main():
                 learning_rate_fn,
                 weight_decay=cfg.training.weight_decay,
                 model=model,
-                grad_accum_steps=cfg.training.gradient_accumulation_steps,
             )
 
             if save_to_bucket:
@@ -274,15 +269,15 @@ def main():
                 f"Running sequence length warmup for {cfg.training.staged_warmup_steps} total steps with stages: {cfg.training.staged_sequences}"
             )
 
-    # if not args.resume:
-    #     if cfg.data.bucket_path is not None:
-    #         # clear bucket
-    #         client = storage.Client()
-    #         if jax.process_index() == 0:
-    #             bucket = storage.Bucket(client, f"{cfg.data.bucket_path}")
-    #             blobs = bucket.list_blobs(prefix=f"{cfg.data.checkpoint_directory}")
-    #             for blob in blobs:
-    #                 blob.delete()
+    if not args.resume:
+        if cfg.data.bucket_path is not None:
+            # clear bucket
+            client = storage.Client()
+            if jax.process_index() == 0:
+                bucket = storage.Bucket(client, f"{cfg.data.bucket_path}")
+                blobs = bucket.list_blobs(prefix=f"{cfg.data.checkpoint_directory}")
+                for blob in blobs:
+                    blob.delete()
 
     local_batch_size = cfg.training.batch_size // (
         jax.local_device_count() // cfg.device.mp_devices
@@ -291,7 +286,6 @@ def main():
     # This is computed in terms of absolute steps
     total_tokens = num_host * (
         cfg.training.batch_size
-        * cfg.training.gradient_accumulation_steps
         * compute_tokens_seen(
             cfg.training.total_steps,
             stages=cfg.training.staged_sequences,
@@ -407,7 +401,7 @@ def main():
         for i, text in enumerate(tqdm(tl, disable=not jax.process_index() == 0)):
 
             if (
-                i // cfg.training.gradient_accumulation_steps
+                i 
             ) > cfg.training.total_steps:
                 if jax.process_index() == 0:
                     logger.debug(f"Training has completed.")
@@ -423,8 +417,8 @@ def main():
 
             text = text.reshape(-1, seq_len)
 
-            # we add a 'grad_accum' batch dimension
-            text = text.reshape(8, text.shape[0]//8, seq_len)
+            # we add a 'grad_accum' batch dimension which we then iterate through in train_step
+            text = text.reshape(cfg.training.gradient_accumulation_steps, text.shape[0]//cfg.training.gradient_accumulation_steps, seq_len)
         
             t0 = time.time()
 
@@ -439,87 +433,80 @@ def main():
 
             running_metrics.append(metrics)
 
-            if (i) % cfg.training.gradient_accumulation_steps == 0:
-                # we've completed a full batch of data, log the metrics
+            train_metrics_np = {
+                k: np.mean([metrics[k] for metrics in running_metrics])
+                for k in running_metrics[0]
+            }
 
-                train_metrics_np = {
-                    k: np.mean([metrics[k] for metrics in running_metrics])
-                    for k in running_metrics[0]
+            running_metrics = []
+            validation_metrics = []
+
+            absolute_step = i 
+
+            train_metrics_np["Tokens Seen (B)"] = (
+                num_host
+                * (
+                    cfg.training.batch_size
+                    * compute_tokens_seen(
+                        absolute_step,
+                        stages=cfg.training.staged_sequences,
+                        max_steps=cfg.training.staged_warmup_steps,
+                        max_context=cfg.data.max_context,
+                    )
+                )
+                / 1e9
+            )
+
+            if (i) % (
+                cfg.training.evaluation_frequency
+            ) == 0:
+                for val_it, val_text in enumerate(
+                    tqdm(vl, disable=not jax.process_index() == 0)
+                ):
+                    val_text = val_text[:,:512]
+                    if val_it < cfg.training.maximum_evaluation_steps:
+                        metrics = pjit_eval_step(state, val_text)
+                        validation_metrics.append(metrics)
+                    else:
+                        break
+
+                validation_metrics_np = {
+                    k: np.mean([metrics[k] for metrics in validation_metrics])
+                    for k in validation_metrics[0]
                 }
 
-                running_metrics = []
-                validation_metrics = []
+                if jax.process_index() == 0:
+                    train_metrics_np.update(validation_metrics_np)
+                    train_metrics_np.pop("Train Batch Time")
+                    wandb.log(train_metrics_np)
 
-                absolute_step = i // cfg.training.gradient_accumulation_steps
-
-                train_metrics_np["Tokens Seen (B)"] = (
-                    num_host
-                    * (
-                        cfg.training.batch_size
-                        * cfg.training.gradient_accumulation_steps
-                        * compute_tokens_seen(
-                            absolute_step,
-                            stages=cfg.training.staged_sequences,
-                            max_steps=cfg.training.staged_warmup_steps,
-                            max_context=cfg.data.max_context,
+                    if cfg.device.mp_devices > 1:
+                        device_state = jax.device_get(
+                            state
+                        )  # pull a copy of the sharded state to CPU and save
+                        save_checkpoint(
+                            device_state,
+                            workdir=f"gs://{cfg.data.bucket_path}/{cfg.data.checkpoint_directory}",
                         )
+
+                    else:
+                        if save_to_bucket:
+                            save_checkpoint(
+                                state,
+                                workdir=f"gs://{cfg.data.bucket_path}/{cfg.data.checkpoint_directory}",
+                            )
+                        else:
+                            save_checkpoint(
+                                state, workdir=cfg.data.checkpoint_directory
+                            )
+
+            else:
+                if jax.process_index() == 0:
+                    train_metrics_np["Train Step Time"] = (
+                        train_metrics_np["Train Batch Time"]
                     )
-                    / 1e9
-                )
-
-                if (i) % (
-                    cfg.training.evaluation_frequency
-                    * cfg.training.gradient_accumulation_steps
-                ) == 0:
-                    for val_it, val_text in enumerate(
-                        tqdm(vl, disable=not jax.process_index() == 0)
-                    ):
-                        val_text = val_text[:,:512]
-                        if val_it < cfg.training.maximum_evaluation_steps:
-                            metrics = pjit_eval_step(state, val_text)
-                            validation_metrics.append(metrics)
-                        else:
-                            break
-
-                    validation_metrics_np = {
-                        k: np.mean([metrics[k] for metrics in validation_metrics])
-                        for k in validation_metrics[0]
-                    }
-
-                    if jax.process_index() == 0:
-                        train_metrics_np.update(validation_metrics_np)
-                        train_metrics_np.pop("Train Batch Time")
-                        wandb.log(train_metrics_np)
-
-                        if cfg.device.mp_devices > 1:
-                            device_state = jax.device_get(
-                                state
-                            )  # pull a copy of the sharded state to CPU and save
-                            # save_checkpoint(
-                            #     device_state,
-                            #     workdir=f"gs://{cfg.data.bucket_path}/{cfg.data.checkpoint_directory}",
-                            # )
-
-                        else:
-                            # if save_to_bucket:
-                            #     save_checkpoint(
-                            #         state,
-                            #         workdir=f"gs://{cfg.data.bucket_path}/{cfg.data.checkpoint_directory}",
-                            #     )
-                            # else:
-                            #     save_checkpoint(
-                            #         state, workdir=cfg.data.checkpoint_directory
-                            #     )
-                            pass 
-
-                else:
-                    if jax.process_index() == 0:
-                        train_metrics_np["Train Step Time"] = (
-                            cfg.training.gradient_accumulation_steps
-                            * train_metrics_np["Train Batch Time"]
-                        )
-                        train_metrics_np.pop("Train Batch Time")
-                        wandb.log(train_metrics_np)
+                    train_metrics_np.pop("Train Batch Time")
+                    wandb.log(train_metrics_np)
 
 
 def train_step(
@@ -530,8 +517,11 @@ def train_step(
 
     """
 
-    # effective BS is (128,512)
-    # loop through this in groups of 16
+    # Based off of Boris Dayma's train step for Dalle Mini
+    # By manually performing gradient accumulation, we avoid 
+    # calling state.apply_gradients when we aren't actually updating the gradients (i.e. part way through a gradient accumulation step)
+    # every time state.apply_gradients is called, we perform an all-sync on the TrainState object when it isn't needed!
+    # This manual implementation results in an approx 3x training speedup
 
     def get_minibatch(batch, grad_idx):
         return jax.tree_util.tree_map(
@@ -551,7 +541,7 @@ def train_step(
 
     grad_fn = jax.value_and_grad(loss_fn, has_aux=False)
 
-    def loss_and_grad(grad_idx): #TODO: Maybe fix dropout rng?
+    def loss_and_grad(grad_idx):
         minibatch = (
                 get_minibatch(batch, grad_idx) if grad_idx is not None else batch
             )
@@ -574,9 +564,18 @@ def train_step(
     def cumul_minibatch_step(grad_idx, cumul_loss_grad):
         cumul_loss, cumul_grads= cumul_loss_grad
         loss, grads = loss_and_grad(grad_idx)
-        cumul_loss, cumul_grads = jax.tree_util.tree_map(
-            jnp.add, (cumul_loss, cumul_grads), (loss, grads)
+        # cumul_loss, cumul_grads = jax.tree_util.tree_map(
+        #     jnp.add, (cumul_loss, cumul_grads), (loss, grads)
+        # )
+
+        # Better approach for computing accumulated gradients. Better numerical stability + we don't have to call another tree_map later
+        cumul_grads = jax.tree_util.tree_map(
+            lambda grad, acc: acc + (grad-acc)/(8 + 1), grads, cumul_grads #TODO: Unhardcode 8 to be the number of accum steps
         )
+        cumul_loss = jax.tree_util.tree_map(
+            lambda loss, acc: acc + (loss-acc)/(8 + 1), loss, cumul_loss #TODO: Unhardcode 8 to be the number of accum steps
+        )
+
         cumul_grads = with_sharding_constraint(cumul_grads, param_spec)
         return cumul_loss, cumul_grads
 
@@ -587,12 +586,8 @@ def train_step(
                 init_minibatch,
             )
     grads = with_sharding_constraint(grads, param_spec)
-    # sum -> mean
-    loss, grads = jax.tree_util.tree_map(
-        lambda x: x / 8, (loss, grads)
-    )
 
-    grads = with_sharding_constraint(grads, param_spec)
+    # grads = with_sharding_constraint(grads, param_spec) 
 
     # only update train_state at the end of a single full batch 
     new_state = state.apply_gradients(

--- a/main.py
+++ b/main.py
@@ -564,17 +564,17 @@ def train_step(
     def cumul_minibatch_step(grad_idx, cumul_loss_grad):
         cumul_loss, cumul_grads= cumul_loss_grad
         loss, grads = loss_and_grad(grad_idx)
-        # cumul_loss, cumul_grads = jax.tree_util.tree_map(
-        #     jnp.add, (cumul_loss, cumul_grads), (loss, grads)
-        # )
+        cumul_loss, cumul_grads = jax.tree_util.tree_map(
+            jnp.add, (cumul_loss, cumul_grads), (loss, grads)
+        )
 
         # Better approach for computing accumulated gradients. Better numerical stability + we don't have to call another tree_map later
-        cumul_grads = jax.tree_util.tree_map(
-            lambda grad, acc: acc + (grad-acc)/(8 + 1), grads, cumul_grads #TODO: Unhardcode 8 to be the number of accum steps
-        )
-        cumul_loss = jax.tree_util.tree_map(
-            lambda loss, acc: acc + (loss-acc)/(8 + 1), loss, cumul_loss #TODO: Unhardcode 8 to be the number of accum steps
-        )
+        # cumul_grads = jax.tree_util.tree_map(
+        #     lambda grad, acc: acc + (grad-acc)/(8 + 1), grads, cumul_grads #TODO: Unhardcode 8 to be the number of accum steps
+        # )
+        # cumul_loss = jax.tree_util.tree_map(
+        #     lambda loss, acc: acc + (loss-acc)/(8 + 1), loss, cumul_loss #TODO: Unhardcode 8 to be the number of accum steps
+        # )
 
         cumul_grads = with_sharding_constraint(cumul_grads, param_spec)
         return cumul_loss, cumul_grads
@@ -585,9 +585,15 @@ def train_step(
                 cumul_minibatch_step,
                 init_minibatch,
             )
+
+
     grads = with_sharding_constraint(grads, param_spec)
 
-    # grads = with_sharding_constraint(grads, param_spec) 
+    loss, grads = jax.tree_util.tree_map(
+                lambda x: x / 8, (loss, grads)
+            )
+
+    grads = with_sharding_constraint(grads, param_spec) 
 
     # only update train_state at the end of a single full batch 
     new_state = state.apply_gradients(

--- a/src/models/layers.py
+++ b/src/models/layers.py
@@ -23,20 +23,20 @@ def get_slopes(n: int) -> List:
             + get_slopes(2 * closest_power_of_2)[0::2][: n - closest_power_of_2]
         )
 
+
 def create_mask(seq_len_k, slopes):
 
     a = -jnp.tril(
-            jnp.tile(
-                jnp.arange(seq_len_k).reshape(seq_len_k, 1), (1, seq_len_k)
-            )
-            + jnp.arange(0, -seq_len_k, step=-1)
-        )
+        jnp.tile(jnp.arange(seq_len_k).reshape(seq_len_k, 1), (1, seq_len_k))
+        + jnp.arange(0, -seq_len_k, step=-1)
+    )
 
     a = a * (slopes.reshape(slopes.shape[0], 1, 1))
 
     alibi_mask = a[:, seq_len_k - 1, :].reshape(a.shape[0], 1, a.shape[2])
 
     return alibi_mask
+
 
 class MLPBlock(nn.Module):
     """Standard MLP Block"""
@@ -102,7 +102,7 @@ class CausalAttention(nn.Module):
                 (self.num_head,),
                 jnp.float32,
             )
-        
+
         self.alibi_mask = create_mask(self.block_size, self.slopes)
 
     @nn.compact
@@ -171,7 +171,7 @@ class CausalAttention(nn.Module):
 
         if self.alibi_attn:
             # NOTE: We are fixing the ALiBi mask since this is for training, during inference or is seq_len changes this will cause issues
-            attn_full = attn_full + self.alibi_mask[:,:T,:T]
+            attn_full = attn_full + self.alibi_mask[:, :T, :T]
 
         mask = jnp.tril(jnp.ones((T, T), dtype=jnp.int8)).reshape(1, 1, T, T)
 

--- a/src/training/training_utils.py
+++ b/src/training/training_utils.py
@@ -47,7 +47,6 @@ def create_train_state(
     learning_rate_fn: Union[float, Callable],
     weight_decay: float,
     model: nn.Module,
-    grad_accum_steps: int,
 ):
     """Creates initial `TrainState` for model."""
     params = initialized(rng, model, input_shape=(1, 512))
@@ -67,13 +66,6 @@ def create_train_state(
             b2=0.95,
         ),
     )
-
-    # if grad_accum_steps > 1:
-    #     tx = optax.MultiSteps(
-    #         tx,
-    #         every_k_schedule=grad_accum_steps,
-    #         should_skip_update_fn=optax.skip_not_finite,
-    #     )
 
     state = TrainState.create(
         apply_fn=model.apply,
@@ -167,7 +159,6 @@ def get_optimizer(
     learning_rate_fn: Union[float, Callable],
     weight_decay: float,
     model: nn.Module,
-    grad_accum_steps: int,
     param_shape: Any,
 ):
     """
@@ -190,10 +181,4 @@ def get_optimizer(
         ),
     )
 
-    if grad_accum_steps > 1:
-        tx = optax.MultiSteps(
-            tx,
-            every_k_schedule=grad_accum_steps,
-            should_skip_update_fn=optax.skip_not_finite,
-        )
     return tx

--- a/src/training/training_utils.py
+++ b/src/training/training_utils.py
@@ -68,12 +68,12 @@ def create_train_state(
         ),
     )
 
-    if grad_accum_steps > 1:
-        tx = optax.MultiSteps(
-            tx,
-            every_k_schedule=grad_accum_steps,
-            should_skip_update_fn=optax.skip_not_finite,
-        )
+    # if grad_accum_steps > 1:
+    #     tx = optax.MultiSteps(
+    #         tx,
+    #         every_k_schedule=grad_accum_steps,
+    #         should_skip_update_fn=optax.skip_not_finite,
+    #     )
 
     state = TrainState.create(
         apply_fn=model.apply,


### PR DESCRIPTION
Changed grad_accum logic related to this: https://wandb.ai/dalle-mini/dalle-mini/reports/JAX-pmap-vs-pjit--VmlldzoxNDg1ODA2

TrainState is only updated once through ```state.apply_gradients``` once a full batch of data is processed instead of being updated every mini accum batch. Should reduce the number all gather operations. 

Other logic in train loop changed to accommodate updated accum logic. Running speed comparison tests now, looks to be around 10-15% faster